### PR TITLE
defines.h: Add missing stddef and stdint includes

### DIFF
--- a/src/vm/defines.h
+++ b/src/vm/defines.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 
 namespace retro8
 {


### PR DESCRIPTION
GCC10 complains about missing size_t, uint8_t, etc