### PR TITLE
Fix implementation of foreach

### DIFF
--- a/data/api.lua
+++ b/data/api.lua
@@ -24,7 +24,7 @@ end
 
 function foreach(c, f)
   if c ~= nil then
-    for key, value in ipairs(c) do
+    for value in all(c) do
       f(value)
     end
   end

--- a/src/gen/lua_api.h
+++ b/src/gen/lua_api.h
@@ -25,7 +25,7 @@ const char* lua_api_string =
 "\n"
 "function foreach(c, f)\n"
 "  if c ~= nil then\n"
-"    for key, value in ipairs(c) do\n"
+"    for value in all(c) do\n"
 "      f(value)\n"
 "    end\n"
 "  end\n"


### PR DESCRIPTION
Oritinal foreach can correctly traverse the table even when the called
function removes the element. Make it in-line with vanilla pico8

Fixe level skipping in celeste classic